### PR TITLE
Add explicit sorting key to sorted call

### DIFF
--- a/training/callbacks/classification_images.py
+++ b/training/callbacks/classification_images.py
@@ -118,7 +118,7 @@ class ClassificationImages(tf.keras.callbacks.Callback):
             )
 
         # Sort by hash so the images show up in the same order every time
-        images = tf.stack([i for h, i in sorted(images)], axis=0)
+        images = tf.stack([i for h, i in sorted(images, key=lambda image: image[0])], axis=0)
 
         with self.writer.as_default():
             # Write the images

--- a/training/callbacks/seeker_images.py
+++ b/training/callbacks/seeker_images.py
@@ -148,7 +148,7 @@ class SeekerImages(tf.keras.callbacks.Callback):
             )
 
         # Sort by hash so the images show up in the same order every time
-        images = tf.stack([i for h, i in sorted(images)], axis=0)
+        images = tf.stack([i for h, i in sorted(images, key=lambda image: image[0])], axis=0)
 
         with self.writer.as_default():
             # Write the images


### PR DESCRIPTION
When sorting the tuple of hashes and images, Python `sorted` would try to convert the images into a bool, triggering a value error. This tells the sort to sort by hash only, bypassing the conversion of images to bool.

```
  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/keras/callbacks.py", line 416, in on_epoch_end
    callback.on_epoch_end(epoch, numpy_logs)
  File "/workspace/training/callbacks/classification_images.py", line 121, in on_epoch_end
    images = tf.stack([i for h, i in sorted(images)], axis=0)
  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/framework/ops.py", line 984, in __bool__
    return bool(self._numpy())
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```