### PR TITLE
Add ability to cache built binaries in OpenCL engine

### DIFF
--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -99,12 +99,13 @@ namespace engine {
 
                 // Compile the program
                 std::cout << "engine 1 before compile" << std::endl;
-                error = ::clBuildProgram(program,
-                                         0,
-                                         nullptr,
-                                         "-cl-single-precision-constant -cl-fast-relaxed-math -cl-mad-enable",
-                                         nullptr,
-                                         nullptr);
+                error =
+                  ::clBuildProgram(program,
+                                   0,
+                                   nullptr,
+                                   "-cl-single-precision-constant -cl-fast-relaxed-math -cl-mad-enable -cl-opt-disable",
+                                   nullptr,
+                                   nullptr);
                 std::cout << "engine 1 after compile" << std::endl;
                 if (error != CL_SUCCESS) {
                     // Get program build log

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -97,7 +97,6 @@ namespace engine {
 
                 // Variables for reading the binary
                 size_t binary_size;
-                std::vector<char> binary_prog{};
 
                 // If the compiled binary exists, read it
                 std::string binary_path = cache_directory + "/" + std::to_string(source_hash) + ".bin";
@@ -109,6 +108,7 @@ namespace engine {
                     read_binary.seekg(0, read_binary.end);
                     binary_size = read_binary.tellg();
                     read_binary.seekg(0, read_binary.beg);
+                    std::vector<char> binary_prog{};
                     binary_prog.reserve(binary_size);
                     // Read the file
                     read_binary.read(binary_prog.data(), binary_size);
@@ -167,7 +167,7 @@ namespace engine {
                     // Save the the built program to a file
                     clGetProgramInfo(program, CL_PROGRAM_BINARY_SIZES, sizeof(size_t), &binary_size, nullptr);
                     std::cout << "reserving" << std::endl;
-                    binary_prog.clear();
+                    std::vector<char> binary_prog{};
                     binary_prog.reserve(binary_size);
                     std::cout << "prog info" << std::endl;
                     clGetProgramInfo(program, CL_PROGRAM_BINARIES, binary_size, binary_prog.data(), nullptr);

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -138,17 +138,17 @@ namespace engine {
                           error, "Error building OpenCL program\n" + std::string(log.begin(), log.begin() + used));
                     }
 
-                    project_rectilinear =
-                      cl::kernel(::clCreateKernel(program, "project_rectilinear", &error), ::clReleaseKernel);
-                    throw_cl_error(error, "Error getting project_rectilinear kernel");
-                    project_equidistant =
-                      cl::kernel(::clCreateKernel(program, "project_equidistant", &error), ::clReleaseKernel);
-                    throw_cl_error(error, "Error getting project_equidistant kernel");
-                    project_equisolid =
-                      cl::kernel(::clCreateKernel(program, "project_equisolid", &error), ::clReleaseKernel);
-                    throw_cl_error(error, "Error getting project_equisolid kernel");
-                    load_image = cl::kernel(::clCreateKernel(program, "load_image", &error), ::clReleaseKernel);
-                    throw_cl_error(error, "Failed to create kernel load_image");
+                    // project_rectilinear =
+                    //   cl::kernel(::clCreateKernel(program, "project_rectilinear", &error), ::clReleaseKernel);
+                    // throw_cl_error(error, "Error getting project_rectilinear kernel");
+                    // project_equidistant =
+                    //   cl::kernel(::clCreateKernel(program, "project_equidistant", &error), ::clReleaseKernel);
+                    // throw_cl_error(error, "Error getting project_equidistant kernel");
+                    // project_equisolid =
+                    //   cl::kernel(::clCreateKernel(program, "project_equisolid", &error), ::clReleaseKernel);
+                    // throw_cl_error(error, "Error getting project_equisolid kernel");
+                    // load_image = cl::kernel(::clCreateKernel(program, "load_image", &error), ::clReleaseKernel);
+                    // throw_cl_error(error, "Failed to create kernel load_image");
 
                     // Save the the built program to a file
                     clGetProgramInfo(program, CL_PROGRAM_BINARY_SIZES, sizeof(size_t), &binary_size, NULL);

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -97,7 +97,7 @@ namespace engine {
 
                 // Variables for reading the binary
                 size_t binary_size;
-                std::vector<char> binary;
+                std::shared_ptr<std::vector<char>> binary = std::make_shared<std::vector<char>>();
 
                 // If the compiled binary exists, read it
                 std::string binary_path = cache_directory + "/" + std::to_string(source_hash) + ".bin";
@@ -108,9 +108,9 @@ namespace engine {
                     read_binary.seekg(0, read_binary.end);
                     binary_size = read_binary.tellg();
                     read_binary.seekg(0, read_binary.beg);
-                    binary.reserve(binary_size);
+                    binary->reserve(binary_size);
                     // Read the file
-                    read_binary.read(&binary[0], binary_size);
+                    read_binary.read(&(binary->front()), binary_size);
                     if (!read_binary) { throw("Read failed"); }
                     read_binary.close();
                 }
@@ -144,13 +144,13 @@ namespace engine {
                     // Save the the built program to a file
                     clGetProgramInfo(program, CL_PROGRAM_BINARY_SIZES, sizeof(size_t), &binary_size, nullptr);
                     std::cout << "reserving" << std::endl;
-                    binary.reserve(binary_size);
+                    binary->reserve(binary_size);
                     std::cout << "prog info" << std::endl;
-                    clGetProgramInfo(program, CL_PROGRAM_BINARIES, binary_size, &binary[0], nullptr);
+                    clGetProgramInfo(program, CL_PROGRAM_BINARIES, binary_size, &(binary->front()), nullptr);
                     std::cout << "make var" << std::endl;
                     std::ofstream write_binary(binary_path, std::ofstream::binary);
                     std::cout << "write" << std::endl;
-                    write_binary.write(&binary[0], binary_size);
+                    write_binary.write(&(binary->front()), binary_size);
                     std::cout << "close" << std::endl;
                     write_binary.close();
                     std::cout << "done" << std::endl;
@@ -158,14 +158,15 @@ namespace engine {
                 std::cout << "Compiling with binary" << std::endl;
                 // Load the binary and build
                 cl_int binary_status = CL_SUCCESS;
-                program              = cl::program(::clCreateProgramWithBinary(context,
-                                                                  1,
-                                                                  &device,
-                                                                  &binary_size,
-                                                                  reinterpret_cast<const unsigned char**>(&binary[0]),
-                                                                  &binary_status,
-                                                                  &error),
-                                      ::clReleaseProgram);
+                program =
+                  cl::program(::clCreateProgramWithBinary(context,
+                                                          1,
+                                                          &device,
+                                                          &binary_size,
+                                                          reinterpret_cast<const unsigned char**>(&(binary->front())),
+                                                          &binary_status,
+                                                          &error),
+                              ::clReleaseProgram);
                 throw_cl_error(error, "Failed to create program from binary");
                 throw_cl_error(binary_status, "Invalid binary");
 

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -185,8 +185,8 @@ namespace engine {
                     std::vector<char> binary_prog{};
                     binary_prog.reserve(binary_size);
                     std::cout << "reserve" << std::endl;
-                    clGetProgramInfo(program, CL_PROGRAM_BINARIES, binary_size, binary_prog.data(), nullptr);
-                    std::cout << "make var " << binary_prog.data() << std::endl;
+                    clGetProgramInfo(program, CL_PROGRAM_BINARIES, binary_size, binary_prog.data(), &error);
+                    std::cout << "make var " << binary_prog.data() << " " << error << std::endl;
                     // try {
                     //     std::ofstream write_binary(binary_path, std::ofstream::binary);
                     //     std::cout << "write" << std::endl;

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -102,56 +102,57 @@ namespace engine {
                 const std::string binary_path = cache_directory + "/" + std::to_string(source_hash) + ".bin";
                 std::ifstream read_binary(binary_path, std::ios::binary);
                 bool read_failed = false;
-                if (read_binary) {
-                    std::cout << "reading binary" << std::endl;
-                    // Get the length
-                    read_binary.seekg(0, read_binary.end);
-                    size_t binary_size = read_binary.tellg();
-                    read_binary.seekg(0, read_binary.beg);
-                    std::vector<char> binary_prog{};
-                    binary_prog.reserve(binary_size);
-                    // Read the file
-                    read_binary.read(binary_prog.data(), binary_size);
-                    if (!read_binary) { read_failed = true; }
+                // if (read_binary) {
+                //     std::cout << "reading binary" << std::endl;
+                //     // Get the length
+                //     read_binary.seekg(0, read_binary.end);
+                //     size_t binary_size = read_binary.tellg();
+                //     read_binary.seekg(0, read_binary.beg);
+                //     std::vector<char> binary_prog{};
+                //     binary_prog.reserve(binary_size);
+                //     // Read the file
+                //     read_binary.read(binary_prog.data(), binary_size);
+                //     if (!read_binary) { read_failed = true; }
 
-                    std::cout << "Compiling with binary" << std::endl;
-                    // Load the binary and build
-                    cl_int binary_status = CL_SUCCESS;
-                    // const unsigned char* thing = reinterpret_cast<unsigned char*>(binary_prog.data());
-                    std::vector<const unsigned char*> binary_progs = {
-                      reinterpret_cast<unsigned char*>(binary_prog.data())};
-                    program =
-                      cl::program(::clCreateProgramWithBinary(
-                                    context, 1, &device, &binary_size, binary_progs.data(), &binary_status, &error),
-                                  ::clReleaseProgram);
-                    if ((error != CL_SUCCESS) || (binary_status != CL_SUCCESS)) { read_failed = true; }
+                //     std::cout << "Compiling with binary" << std::endl;
+                //     // Load the binary and build
+                //     cl_int binary_status = CL_SUCCESS;
+                //     // const unsigned char* thing = reinterpret_cast<unsigned char*>(binary_prog.data());
+                //     std::vector<const unsigned char*> binary_progs = {
+                //       reinterpret_cast<unsigned char*>(binary_prog.data())};
+                //     program =
+                //       cl::program(::clCreateProgramWithBinary(
+                //                     context, 1, &device, &binary_size, binary_progs.data(), &binary_status, &error),
+                //                   ::clReleaseProgram);
+                //     if ((error != CL_SUCCESS) || (binary_status != CL_SUCCESS)) { read_failed = true; }
 
-                    error = ::clBuildProgram(program,
-                                             1,
-                                             &device,
-                                             "-cl-single-precision-constant -cl-fast-relaxed-math -cl-mad-enable",
-                                             nullptr,
-                                             nullptr);
+                //     error = ::clBuildProgram(program,
+                //                              1,
+                //                              &device,
+                //                              "-cl-single-precision-constant -cl-fast-relaxed-math -cl-mad-enable",
+                //                              nullptr,
+                //                              nullptr);
 
-                    // If it didn't work, try rebuilding
-                    if (error != CL_SUCCESS) { read_failed = true; }
-                }
-                read_binary.close();
+                //     // If it didn't work, try rebuilding
+                //     if (error != CL_SUCCESS) { read_failed = true; }
+                // }
+                // read_binary.close();
 
-                // If the read failed, remove the file
-                if (read_failed) {
-                    std::cout << "read failed, remove the file " << std::endl;
-                    std::remove(binary_path.c_str());
+                // // If the read failed, remove the file
+                // if (read_failed) {
+                //     std::cout << "read failed, remove the file " << std::endl;
+                //     std::remove(binary_path.c_str());
 
-                    // reset vars
-                    error                     = CL_SUCCESS;
-                    device                    = nullptr;
-                    std::tie(context, device) = operation::make_context();
-                    queue                     = operation::make_queue(context, device);
-                }
+                //     // reset vars
+                //     error                     = CL_SUCCESS;
+                //     device                    = nullptr;
+                //     std::tie(context, device) = operation::make_context();
+                //     queue                     = operation::make_queue(context, device);
+                // }
 
                 // The compiled binary doesn't exist, create it
-                if (!read_binary || read_failed) {
+                // if (!read_binary || read_failed) {
+                if (true) {
                     std::cout << "building program" << std::endl;
                     // Create the program and build
                     program =

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -96,10 +96,7 @@ namespace engine {
                 size_t csize       = source.size();
                 // The hash of the sources represents the name of the OpenCL compiled program binary file, so that a new
                 // binary will be created for different sources
-                std::size_t source_hash = std::hash<std::string>{}(source);
-
-                // Variables for reading the binary
-                size_t binary_size;
+                const std::size_t source_hash = std::hash<std::string>{}(source);
 
                 // If the compiled binary exists, read it
                 const std::string binary_path = cache_directory + "/" + std::to_string(source_hash) + ".bin";
@@ -109,7 +106,7 @@ namespace engine {
                     std::cout << "reading binary" << std::endl;
                     // Get the length
                     read_binary.seekg(0, read_binary.end);
-                    binary_size = read_binary.tellg();
+                    size_t binary_size = read_binary.tellg();
                     read_binary.seekg(0, read_binary.beg);
                     std::vector<char> binary_prog{};
                     binary_prog.reserve(binary_size);
@@ -175,6 +172,7 @@ namespace engine {
                     }
                     std::cout << "built" << std::endl;
                     // Save the the built program to a file
+                    size_t binary_size{};
                     clGetProgramInfo(program, CL_PROGRAM_BINARY_SIZES, sizeof(size_t), &binary_size, nullptr);
                     std::cout << "reserving" << std::endl;
                     std::vector<char> binary_prog{};

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -103,7 +103,7 @@ namespace engine {
 
                 // If the compiled binary exists, read it
                 const std::string binary_path = cache_directory + "/" + std::to_string(source_hash) + ".bin";
-                std::ifstream read_binary(binary_path, std::ios::in);
+                std::ifstream read_binary(binary_path, std::ios::binary);
                 bool read_failed = false;
                 if (read_binary) {
                     std::cout << "reading binary" << std::endl;

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -185,8 +185,8 @@ namespace engine {
                     std::vector<char> binary_prog{};
                     binary_prog.reserve(binary_size);
                     std::cout << "reserve" << std::endl;
-                    // clGetProgramInfo(program, CL_PROGRAM_BINARIES, binary_size, binary_prog.data(), nullptr);
-                    // std::cout << "make var" << std::endl;
+                    clGetProgramInfo(program, CL_PROGRAM_BINARIES, binary_size, binary_prog.data(), nullptr);
+                    std::cout << "make var " << binary_prog.data() << std::endl;
                     // try {
                     //     std::ofstream write_binary(binary_path, std::ofstream::binary);
                     //     std::cout << "write" << std::endl;

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -115,7 +115,9 @@ namespace engine {
                         std::vector<char> binary_load(binary_size, 0);
                         // Read the file
                         read_binary.read(binary_load.data(), binary_size);
-                        if (!read_binary) { throw std::runtime_error("Failed to read from precompiled OpenCL binary.") }
+                        if (!read_binary) {
+                            throw std::runtime_error("Failed to read from precompiled OpenCL binary.");
+                        }
                         read_binary.close();
 
                         // Load the binary and build

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -97,7 +97,7 @@ namespace engine {
 
                 // Variables for reading the binary
                 size_t binary_size;
-                std::shared_ptr<std::vector<char>> binary = std::make_shared<std::vector<char>>();
+                std::shared_ptr<std::vector<char>> binary_prog = std::make_shared<std::vector<char>>();
 
                 // If the compiled binary exists, read it
                 std::string binary_path = cache_directory + "/" + std::to_string(source_hash) + ".bin";
@@ -108,9 +108,9 @@ namespace engine {
                     read_binary.seekg(0, read_binary.end);
                     binary_size = read_binary.tellg();
                     read_binary.seekg(0, read_binary.beg);
-                    binary->reserve(binary_size);
+                    binary_prog->reserve(binary_size);
                     // Read the file
-                    read_binary.read(&(binary->front()), binary_size);
+                    read_binary.read(&(binary_prog->front()), binary_size);
                     if (!read_binary) { throw("Read failed"); }
                     read_binary.close();
                 }
@@ -146,11 +146,11 @@ namespace engine {
                     std::cout << "reserving" << std::endl;
                     binary->reserve(binary_size);
                     std::cout << "prog info" << std::endl;
-                    clGetProgramInfo(program, CL_PROGRAM_BINARIES, binary_size, &(binary->front()), nullptr);
-                    std::cout << "make var" << std::endl;
+                    clGetProgramInfo(program, CL_PROGRAM_BINARIES, binary_size, &(binary_prog->front()), nullptr);
+                    std::cout << "make var " << binary_size << std::endl;
                     std::ofstream write_binary(binary_path, std::ofstream::binary);
                     std::cout << "write" << std::endl;
-                    write_binary.write(&(binary->front()), binary_size);
+                    write_binary.write(&(binary_prog->front()), binary_size);
                     std::cout << "close" << std::endl;
                     write_binary.close();
                     std::cout << "done" << std::endl;
@@ -158,15 +158,15 @@ namespace engine {
                 std::cout << "Compiling with binary" << std::endl;
                 // Load the binary and build
                 cl_int binary_status = CL_SUCCESS;
-                program =
-                  cl::program(::clCreateProgramWithBinary(context,
-                                                          1,
-                                                          &device,
-                                                          &binary_size,
-                                                          reinterpret_cast<const unsigned char**>(&(binary->front())),
-                                                          &binary_status,
-                                                          &error),
-                              ::clReleaseProgram);
+                program              = cl::program(
+                  ::clCreateProgramWithBinary(context,
+                                              1,
+                                              &device,
+                                              &binary_size,
+                                              reinterpret_cast<const unsigned char**>(&(binary_prog->front())),
+                                              &binary_status,
+                                              &error),
+                  ::clReleaseProgram);
                 throw_cl_error(error, "Failed to create program from binary");
                 throw_cl_error(binary_status, "Invalid binary");
 

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -22,7 +22,6 @@
 #if !defined(VISUALMESH_DISABLE_OPENCL)
 
 #include <fstream>
-#include <hash_map>
 #include <iomanip>
 #include <iostream>
 #include <numeric>
@@ -100,10 +99,9 @@ namespace engine {
                 size_t binary_size;
                 char* binary;
 
-                // The compiled binary exists, read it
+                // If the compiled binary exists, read it
                 std::string binary_path = cache_directory + "/" + std::to_string(source_hash) + ".bin";
                 std::ifstream read_binary(binary_path, std::ios::in);
-
                 if (read_binary) {
                     // Get the length
                     read_binary.seekg(0, read_binary.end);
@@ -121,6 +119,7 @@ namespace engine {
                     program =
                       cl::program(::clCreateProgramWithSource(context, 1, &cstr, &csize, &error), ::clReleaseProgram);
                     throw_cl_error(error, "Error adding sources to OpenCL program");
+
                     error = ::clBuildProgram(program,
                                              0,
                                              nullptr,
@@ -169,7 +168,12 @@ namespace engine {
 
                 delete[] binary;  // done with the binary so delete it
 
-                error = clBuildProgram(program, 1, &device, NULL, NULL, NULL);
+                error = ::clBuildProgram(program,
+                                         1,
+                                         &device,
+                                         "-cl-single-precision-constant -cl-fast-relaxed-math -cl-mad-enable",
+                                         NULL,
+                                         NULL);
                 // If it didn't work, log and throw an error
                 if (error != CL_SUCCESS) {
                     // Get program build log

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -116,7 +116,6 @@ namespace engine {
                     // Read the file
                     read_binary.read(binary_prog.data(), binary_size);
                     if (!read_binary) { read_failed = true; }
-                    read_binary.close();
 
                     std::cout << "Compiling with binary" << std::endl;
                     // Load the binary and build
@@ -140,6 +139,7 @@ namespace engine {
                     // If it didn't work, try rebuilding
                     if (error != CL_SUCCESS) { read_failed = true; }
                 }
+                read_binary.close();
 
                 // If the read failed, remove the file
                 if (read_failed) {

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -121,7 +121,7 @@ namespace engine {
                     // Load the binary and build
                     cl_int binary_status = CL_SUCCESS;
                     // const unsigned char* thing = reinterpret_cast<unsigned char*>(binary_prog.data());
-                    std::array<const unsigned char*, 1> binary_progs = {
+                    std::vector<const unsigned char*> binary_progs = {
                       reinterpret_cast<unsigned char*>(binary_prog.data())};
                     program =
                       cl::program(::clCreateProgramWithBinary(
@@ -139,9 +139,10 @@ namespace engine {
                     // If it didn't work, try rebuilding
                     if (error != CL_SUCCESS) { read_failed = true; }
                 }
+
                 // If the read failed, remove the file
                 if (read_failed) {
-                    std::cout << "read failed, remove the file " << binary_size << std::endl;
+                    std::cout << "read failed, remove the file " << std::endl;
                     std::remove(binary_path.c_str());
                 }
 

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -124,16 +124,15 @@ namespace engine {
              * @brief Build the OpenCL program
              *
              * @param device OpenCL device id
-             * @param cstr OpenCL source information as a string
-             * @param csize size of the OpenCL source information
+             * @param source OpenCL source information
              */
             void build_from_source(cl_device_id& device, const std::string& source) {
                 // Error flag to check if any OpenCL functions fail
                 cl_int error = CL_SUCCESS;
 
                 // Create the program and build
-                const char* cstr   = source.c_str();
-                size_t csize       = source.size();
+                const char* cstr = source.c_str();
+                size_t csize     = source.size();
                 program =
                   cl::program(::clCreateProgramWithSource(context, 1, &cstr, &csize, &error), ::clReleaseProgram);
                 throw_cl_error(error, "Error adding sources to OpenCL program");
@@ -219,7 +218,7 @@ namespace engine {
                 }
                 // The compiled binary doesn't exist, create it
                 catch (std::exception& /* e */) {
-                    build_binary(device, source);
+                    build_from_source(device, source);
                     save_binary(binary_path);
                 }
 

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -123,7 +123,7 @@ namespace engine {
                     read_binary.read(binary, length);
                     if (!read_binary) { throw("Read failed"); }
                     read_binary.close();
-                    std::cout << "engine close file" << &binary << std::endl;
+                    std::cout << "engine close file " << binary << std::endl;
                 }
                 // The compiled binary doesn't exist, create it
                 else {
@@ -159,7 +159,7 @@ namespace engine {
                     std::ofstream write_binary(binary_path, std::ofstream::binary);
                     std::cout << "engine about to write" << std::endl;
                     write_binary.write(binary, binary_size);
-                    std::cout << "engine written" << std::endl;
+                    std::cout << "engine written " << binary << std::endl;
                     write_binary.close();
                     std::cout << "engine saved" << std::endl;
                 }

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -138,18 +138,6 @@ namespace engine {
                           error, "Error building OpenCL program\n" + std::string(log.begin(), log.begin() + used));
                     }
 
-                    // project_rectilinear =
-                    //   cl::kernel(::clCreateKernel(program, "project_rectilinear", &error), ::clReleaseKernel);
-                    // throw_cl_error(error, "Error getting project_rectilinear kernel");
-                    // project_equidistant =
-                    //   cl::kernel(::clCreateKernel(program, "project_equidistant", &error), ::clReleaseKernel);
-                    // throw_cl_error(error, "Error getting project_equidistant kernel");
-                    // project_equisolid =
-                    //   cl::kernel(::clCreateKernel(program, "project_equisolid", &error), ::clReleaseKernel);
-                    // throw_cl_error(error, "Error getting project_equisolid kernel");
-                    // load_image = cl::kernel(::clCreateKernel(program, "load_image", &error), ::clReleaseKernel);
-                    // throw_cl_error(error, "Failed to create kernel load_image");
-
                     // Save the the built program to a file
                     clGetProgramInfo(program, CL_PROGRAM_BINARY_SIZES, sizeof(size_t), &binary_size, NULL);
                     binary = new char[binary_size];
@@ -587,7 +575,9 @@ namespace engine {
                     // Cache for future runs
                     device_points_cache[&mesh] = cl_points;
                 }
-                else { cl_points = device_mesh->second; }
+                else { 
+                    cl_points = device_mesh->second; 
+                }
 
                 // First count the size of the buffer we will need to allocate
                 int n_points = 0;
@@ -694,6 +684,7 @@ namespace engine {
                 // finished If we don't do this here, some of our buffers can go out of scope before the queue picks
                 // them up causing errors
                 ::clFlush(queue);
+
                 // Return what we calculated
                 return std::make_tuple(std::move(local_neighbourhood),  // CPU buffer
                                        std::move(indices),              // CPU buffer

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -21,6 +21,7 @@
 // If OpenCL is disabled then don't provide this file
 #if !defined(VISUALMESH_DISABLE_OPENCL)
 
+#include <filesystem>
 #include <iomanip>
 #include <iostream>
 #include <numeric>
@@ -48,20 +49,20 @@ namespace visualmesh {
 namespace engine {
     namespace opencl {
 
-        using fs = std::filesystem
+        using fs = std::filesystem;
 
-          /**
-           * @brief An OpenCL implementation of the visual mesh inference engine
-           *
-           * @details
-           *  The OpenCL implementation is designed to be used for high performance inference. It is able to take
-           *  advantage of either GPUs from Intel, AMD, ARM, NVIDIA etc as well as multithreaded CPU implementations.
-           *  This allows it to be very flexible with its deployment on devices.
-           *
-           * @tparam Scalar the scalar type used for calculations and storage (normally one of float or double)
-           */
-          template <typename Scalar>
-          class Engine {
+        /**
+         * @brief An OpenCL implementation of the visual mesh inference engine
+         *
+         * @details
+         *  The OpenCL implementation is designed to be used for high performance inference. It is able to take
+         *  advantage of either GPUs from Intel, AMD, ARM, NVIDIA etc as well as multithreaded CPU implementations.
+         *  This allows it to be very flexible with its deployment on devices.
+         *
+         * @tparam Scalar the scalar type used for calculations and storage (normally one of float or double)
+         */
+        template <typename Scalar>
+        class Engine {
         private:
             // OpenCL ::clSetKernelArg functions take the sizeof a pointer as their argument, this is correct
             static constexpr size_t MEM_SIZE = sizeof(cl_mem);

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -185,10 +185,10 @@ namespace engine {
                 throw_cl_error(error, "Failed to create program from binary");
                 std::cout << "engine create with binary " << binary_status << " " << error << std::endl;
 
-                for (int i = 0; i < length; i++) {
-                    std::cout << binary[i];
-                }
-                std::cout << std::endl;
+                // for (int i = 0; i < binary_size; i++) {
+                //     std::cout << binary[i];
+                // }
+                // std::cout << std::endl;
 
                 delete[] binary;  // done with the binary so delete it
                 std::cout << "engine deleted the binary" << std::endl;

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -184,15 +184,15 @@ namespace engine {
                     std::cout << "make var" << std::endl;
                     try {
                         std::ofstream write_binary(binary_path, std::ofstream::binary);
+                        std::cout << "write" << std::endl;
+                        write_binary.write(binary_prog.data(), binary_size);
+                        std::cout << "close" << std::endl;
+                        write_binary.close();
+                        std::cout << "done" << std::endl;
                     }
                     catch (const std::exception& e) {
                         std::cout << e.what();
                     }
-                    std::cout << "write" << std::endl;
-                    write_binary.write(binary_prog.data(), binary_size);
-                    std::cout << "close" << std::endl;
-                    write_binary.close();
-                    std::cout << "done" << std::endl;
                 }
                 std::cout << "done" << std::endl;
                 // Get the kernels

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -109,17 +109,17 @@ namespace engine {
                 std::string binary_path = cache_directory + "/" + std::to_string(source_hash) + ".bin";
                 std::ifstream read_binary(binary_path, std::ios::in);
                 std::cout << "engine try read" << std::endl;
-                long length = 0;
+
                 if (read_binary) {
                     std::cout << "engine reading" << std::endl;
                     // Get the length
                     read_binary.seekg(0, read_binary.end);
-                    length = read_binary.tellg();
+                    binary_size = read_binary.tellg();
                     read_binary.seekg(0, read_binary.beg);
-                    std::cout << "engine length " << length << std::endl;
-                    binary = new char[length];
+                    std::cout << "engine binary_size " << binary_size << std::endl;
+                    binary = new char[binary_size];
                     // Read the file
-                    read_binary.read(binary, length);
+                    read_binary.read(binary, binary_size);
                     if (!read_binary) { throw("Read failed"); }
                     read_binary.close();
                     std::cout << "engine close file " << std::endl;

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -123,7 +123,10 @@ namespace engine {
                     read_binary.read(binary, length);
                     if (!read_binary) { throw("Read failed"); }
                     read_binary.close();
-                    std::cout << "engine close file " << binary << std::endl;
+                    std::cout << "engine close file " << std::endl;
+                    for (auto& b : binary) {
+                        std::cout << b << std::endl;
+                    }
                 }
                 // The compiled binary doesn't exist, create it
                 else {
@@ -150,6 +153,19 @@ namespace engine {
                         throw_cl_error(
                           error, "Error building OpenCL program\n" + std::string(log.begin(), log.begin() + used));
                     }
+
+                    project_rectilinear =
+                      cl::kernel(::clCreateKernel(binary_program, "project_rectilinear", &error), ::clReleaseKernel);
+                    throw_cl_error(error, "Error getting project_rectilinear kernel");
+                    project_equidistant =
+                      cl::kernel(::clCreateKernel(binary_program, "project_equidistant", &error), ::clReleaseKernel);
+                    throw_cl_error(error, "Error getting project_equidistant kernel");
+                    project_equisolid =
+                      cl::kernel(::clCreateKernel(binary_program, "project_equisolid", &error), ::clReleaseKernel);
+                    throw_cl_error(error, "Error getting project_equisolid kernel");
+                    load_image = cl::kernel(::clCreateKernel(binary_program, "load_image", &error), ::clReleaseKernel);
+                    throw_cl_error(error, "Failed to create kernel load_image");
+
                     std::cout << "engine about to save" << std::endl;
                     // Save the the built program to a file
                     clGetProgramInfo(program, CL_PROGRAM_BINARY_SIZES, sizeof(size_t), &binary_size, NULL);

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -99,9 +99,9 @@ namespace engine {
                 const std::size_t source_hash = std::hash<std::string>{}(source);
 
                 // If the compiled binary exists, read it
-                const std::string binary_path = cache_directory + "/" + std::to_string(source_hash) + ".bin";
-                std::ifstream read_binary(binary_path, std::ios::binary);
-                bool read_failed = false;
+                // const std::string binary_path = cache_directory + "/" + std::to_string(source_hash) + ".bin";
+                // std::ifstream read_binary(binary_path, std::ios::binary);
+                // bool read_failed = false;
                 // if (read_binary) {
                 //     std::cout << "reading binary" << std::endl;
                 //     // Get the length
@@ -178,26 +178,26 @@ namespace engine {
                           error, "Error building OpenCL program\n" + std::string(log.begin(), log.begin() + used));
                     }
                     std::cout << "built" << std::endl;
-                    // Save the the built program to a file
-                    size_t binary_size{};
-                    clGetProgramInfo(program, CL_PROGRAM_BINARY_SIZES, sizeof(size_t), &binary_size, nullptr);
-                    std::cout << "reserving" << std::endl;
-                    std::vector<char> binary_prog{};
-                    binary_prog.reserve(binary_size);
-                    std::cout << "prog info" << std::endl;
-                    clGetProgramInfo(program, CL_PROGRAM_BINARIES, binary_size, binary_prog.data(), nullptr);
-                    std::cout << "make var" << std::endl;
-                    try {
-                        std::ofstream write_binary(binary_path, std::ofstream::binary);
-                        std::cout << "write" << std::endl;
-                        write_binary.write(binary_prog.data(), binary_size);
-                        std::cout << "close" << std::endl;
-                        write_binary.close();
-                        std::cout << "done" << std::endl;
-                    }
-                    catch (const std::exception& e) {
-                        std::cout << e.what();
-                    }
+                    // // Save the the built program to a file
+                    // size_t binary_size{};
+                    // clGetProgramInfo(program, CL_PROGRAM_BINARY_SIZES, sizeof(size_t), &binary_size, nullptr);
+                    // std::cout << "reserving" << std::endl;
+                    // std::vector<char> binary_prog{};
+                    // binary_prog.reserve(binary_size);
+                    // std::cout << "prog info" << std::endl;
+                    // clGetProgramInfo(program, CL_PROGRAM_BINARIES, binary_size, binary_prog.data(), nullptr);
+                    // std::cout << "make var" << std::endl;
+                    // try {
+                    //     std::ofstream write_binary(binary_path, std::ofstream::binary);
+                    //     std::cout << "write" << std::endl;
+                    //     write_binary.write(binary_prog.data(), binary_size);
+                    //     std::cout << "close" << std::endl;
+                    //     write_binary.close();
+                    //     std::cout << "done" << std::endl;
+                    // }
+                    // catch (const std::exception& e) {
+                    //     std::cout << e.what();
+                    // }
                 }
                 std::cout << "done" << std::endl;
                 // Get the kernels

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -188,6 +188,7 @@ namespace engine {
                     std::cout << "reserve" << std::endl;
                     clGetProgramInfo(program, CL_PROGRAM_BINARIES, binary_size, binary_prog, nullptr);
                     std::cout << "make var " << std::endl;
+                    delete[] binary_prog;
                     // try {
                     //     std::ofstream write_binary(binary_path, std::ofstream::binary);
                     //     std::cout << "write" << std::endl;

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -182,7 +182,12 @@ namespace engine {
                     std::cout << "prog info" << std::endl;
                     clGetProgramInfo(program, CL_PROGRAM_BINARIES, binary_size, binary_prog.data(), nullptr);
                     std::cout << "make var" << std::endl;
-                    std::ofstream write_binary(binary_path, std::ofstream::binary);
+                    try {
+                        std::ofstream write_binary(binary_path, std::ofstream::binary);
+                    }
+                    catch (const std::exception& e) {
+                        std::cout << e.what();
+                    }
                     std::cout << "write" << std::endl;
                     write_binary.write(binary_prog.data(), binary_size);
                     std::cout << "close" << std::endl;

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -165,9 +165,9 @@ namespace engine {
                 }
                 std::cout << "engine loading the binary" << std::endl;
                 // Load the binary and build
-                cl_int binary_status = CL_SUCCESS;
-                cl_program binary_program =
-                  ::clCreateProgramWithBinary(context, 1, &device, &binary_size, &binary, &binary_status, &error);
+                cl_int binary_status      = CL_SUCCESS;
+                cl_program binary_program = ::clCreateProgramWithBinary(
+                  context, 1, &device, &binary_size, (const unsigned char**) &binary, &binary_status, &error);
                 std::cout << "engine create with binary " << binary_status << " " << error << std::endl;
                 delete[] binary;  // done with the binary so delete it
                 std::cout << "engine deleted the binary" << std::endl;

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -178,10 +178,10 @@ namespace engine {
                           error, "Error building OpenCL program\n" + std::string(log.begin(), log.begin() + used));
                     }
                     std::cout << "built" << std::endl;
-                    // // Save the the built program to a file
-                    // size_t binary_size{};
-                    // clGetProgramInfo(program, CL_PROGRAM_BINARY_SIZES, sizeof(size_t), &binary_size, nullptr);
-                    // std::cout << "reserving" << std::endl;
+                    // Save the the built program to a file
+                    size_t binary_size{};
+                    clGetProgramInfo(program, CL_PROGRAM_BINARY_SIZES, sizeof(size_t), &binary_size, nullptr);
+                    std::cout << "get the binary size" << std::endl;
                     // std::vector<char> binary_prog{};
                     // binary_prog.reserve(binary_size);
                     // std::cout << "prog info" << std::endl;

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -21,6 +21,8 @@
 // If OpenCL is disabled then don't provide this file
 #if !defined(VISUALMESH_DISABLE_OPENCL)
 
+#include <stdio.h>
+
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -137,6 +139,12 @@ namespace engine {
                     // If it didn't work, try rebuilding
                     if (error != CL_SUCCESS) { read_failed = true; }
                 }
+                // If the read failed, remove the file
+                if (read_failed) {
+                    std::cout << "read failed, remove the file " << binary_size << std::endl;
+                    std::remove(binary_path);
+                }
+
                 // The compiled binary doesn't exist, create it
                 if (!read_binary || read_failed) {
                     std::cout << "building program" << std::endl;
@@ -171,7 +179,7 @@ namespace engine {
                     binary_prog.reserve(binary_size);
                     std::cout << "prog info" << std::endl;
                     clGetProgramInfo(program, CL_PROGRAM_BINARIES, binary_size, binary_prog.data(), nullptr);
-                    std::cout << "make var " << binary_size << std::endl;
+                    std::cout << "make var" << std::endl;
                     std::ofstream write_binary(binary_path, std::ofstream::binary);
                     std::cout << "write" << std::endl;
                     write_binary.write(binary_prog.data(), binary_size);

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -169,7 +169,7 @@ namespace engine {
                 cl_program binary_program = ::clCreateProgramWithBinary(
                   context, 1, &device, &binary_size, (const unsigned char**) &binary, &binary_status, &error);
                 std::cout << "engine create with binary" << std::endl;
-                delete[] binary;  // done with the binary so delete it
+                delete binary;  // done with the binary so delete it
                 std::cout << "engine deleted the binary" << std::endl;
                 clBuildProgram(binary_program, 1, &device, NULL, NULL, NULL);
                 std::cout << "engine build the program" << std::endl;
@@ -581,9 +581,7 @@ namespace engine {
                     // Cache for future runs
                     device_points_cache[&mesh] = cl_points;
                 }
-                else {
-                    cl_points = device_mesh->second;
-                }
+                else { cl_points = device_mesh->second; }
 
                 // First count the size of the buffer we will need to allocate
                 int n_points = 0;

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -98,12 +98,14 @@ namespace engine {
                 throw_cl_error(error, "Error adding sources to OpenCL program");
 
                 // Compile the program
+                std::cout << "engine 1 before compile" << std::endl;
                 error = ::clBuildProgram(program,
                                          0,
                                          nullptr,
                                          "-cl-single-precision-constant -cl-fast-relaxed-math -cl-mad-enable",
                                          nullptr,
                                          nullptr);
+                std::cout << "engine 1 after compile" << std::endl;
                 if (error != CL_SUCCESS) {
                     // Get program build log
                     size_t used = 0;

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -103,6 +103,7 @@ namespace engine {
                 std::string binary_path = cache_directory + "/" + std::to_string(source_hash) + ".bin";
                 std::ifstream read_binary(binary_path, std::ios::in);
                 if (read_binary) {
+                    std::cout << "reading binary" << std::endl;
                     // Get the length
                     read_binary.seekg(0, read_binary.end);
                     binary_size = read_binary.tellg();
@@ -115,6 +116,7 @@ namespace engine {
                 }
                 // The compiled binary doesn't exist, create it
                 else {
+                    std::cout << "building program" << std::endl;
                     // Create the program and build
                     program =
                       cl::program(::clCreateProgramWithSource(context, 1, &cstr, &csize, &error), ::clReleaseProgram);
@@ -147,7 +149,7 @@ namespace engine {
                     write_binary.write(&binary[0], binary_size);
                     write_binary.close();
                 }
-
+                std::cout << "Compiling with binary" << std::endl;
                 // Load the binary and build
                 cl_int binary_status = CL_SUCCESS;
                 program              = cl::program(::clCreateProgramWithBinary(context,
@@ -179,7 +181,7 @@ namespace engine {
                     throw_cl_error(error,
                                    "Error building OpenCL program\n" + std::string(log.begin(), log.begin() + used));
                 }
-
+                std::cout << "done" << std::endl;
                 // Get the kernels
                 project_rectilinear =
                   cl::kernel(::clCreateKernel(program, "project_rectilinear", &error), ::clReleaseKernel);

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -101,7 +101,7 @@ namespace engine {
                 size_t binary_size;
 
                 // If the compiled binary exists, read it
-                std::string binary_path = cache_directory + "/" + std::to_string(source_hash) + ".bin";
+                const std::string binary_path = cache_directory + "/" + std::to_string(source_hash) + ".bin";
                 std::ifstream read_binary(binary_path, std::ios::in);
                 bool read_failed = false;
                 if (read_binary) {
@@ -142,7 +142,7 @@ namespace engine {
                 // If the read failed, remove the file
                 if (read_failed) {
                     std::cout << "read failed, remove the file " << binary_size << std::endl;
-                    std::remove(binary_path);
+                    std::remove(binary_path.c_str());
                 }
 
                 // The compiled binary doesn't exist, create it

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -182,9 +182,9 @@ namespace engine {
                     size_t binary_size{};
                     clGetProgramInfo(program, CL_PROGRAM_BINARY_SIZES, sizeof(size_t), &binary_size, nullptr);
                     std::cout << "get the binary size" << std::endl;
-                    // std::vector<char> binary_prog{};
-                    // binary_prog.reserve(binary_size);
-                    // std::cout << "prog info" << std::endl;
+                    std::vector<char> binary_prog{};
+                    binary_prog.reserve(binary_size);
+                    std::cout << "reserve" << std::endl;
                     // clGetProgramInfo(program, CL_PROGRAM_BINARIES, binary_size, binary_prog.data(), nullptr);
                     // std::cout << "make var" << std::endl;
                     // try {

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -124,7 +124,7 @@ namespace engine {
                 }
             }
 
-            void save_build_binary() {
+            void save_build_binary(std::string binary_path, cl_device_id& device, const char* cstr, size_t csize) {
                 cl_int error = CL_SUCCESS;
 
                 std::cout << "creating binary" << std::endl;
@@ -204,7 +204,7 @@ namespace engine {
                 bool read_failed = load_build_binary(binary_path, device);
 
                 // The compiled binary doesn't exist, create it
-                if (read_failed) { save_build_binary(); }
+                if (read_failed) { save_build_binary(binary_path, device, cstr, csize); }
 
                 std::cout << "kernels" << std::endl;
                 // Get the kernels

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -112,8 +112,6 @@ namespace engine {
                 long length = 0;
                 if (read_binary) {
                     std::cout << "engine reading" << std::endl;
-                    char* binary;
-
                     // Get the length
                     read_binary.seekg(0, read_binary.end);
                     length = read_binary.tellg();

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -75,6 +75,7 @@ namespace engine {
              */
 
             Engine(const NetworkStructure<Scalar>& structure = {}, std::string cache_directory = "") {
+                std::cout << "start" << std::endl;
                 // Create the OpenCL context and command queue
                 cl_int error              = CL_SUCCESS;
                 cl_device_id device       = nullptr;
@@ -201,7 +202,7 @@ namespace engine {
                 throw_cl_error(error, "Error getting project_equisolid kernel");
                 load_image = cl::kernel(::clCreateKernel(program, "load_image", &error), ::clReleaseKernel);
                 throw_cl_error(error, "Failed to create kernel load_image");
-
+                std::cout << "kernels" << std::endl;
                 // Grab all the kernels that were generated
                 for (unsigned int i = 0; i < structure.size(); ++i) {
                     std::string kernel       = "conv" + std::to_string(i);
@@ -211,7 +212,7 @@ namespace engine {
                     throw_cl_error(error, "Failed to create kernel " + kernel);
                     conv_layers.emplace_back(k, output_size);
                 }
-
+                std::cout << "network stuff" << std::endl;
                 // Work out what the widest network layer is
                 max_width = 4;
                 for (const auto& k : conv_layers) {
@@ -235,6 +236,7 @@ namespace engine {
                 for (const auto& k : conv_layers) {
                     workgroup_size = std::max(workgroup_size, workgroup_size_for_kernel(k.first));
                 }
+                std::cout << "end" << std::endl;
             }
 
             /**

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -124,10 +124,6 @@ namespace engine {
                     if (!read_binary) { throw("Read failed"); }
                     read_binary.close();
                     std::cout << "engine close file " << std::endl;
-                    for (int i = 0; i < length; i++) {
-                        std::cout << binary[i];
-                    }
-                    std::cout << std::endl;
                 }
                 // The compiled binary doesn't exist, create it
                 else {
@@ -187,6 +183,7 @@ namespace engine {
                   ::clCreateProgramWithBinary(
                     context, 1, &device, &binary_size, (const unsigned char**) &binary, &binary_status, &error),
                   ::clReleaseProgram);
+                throw_cl_error(error, "Failed to create program from binary");
                 std::cout << "engine create with binary " << binary_status << " " << error << std::endl;
                 delete[] binary;  // done with the binary so delete it
                 std::cout << "engine deleted the binary" << std::endl;

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -165,11 +165,11 @@ namespace engine {
                 }
                 std::cout << "engine loading the binary" << std::endl;
                 // Load the binary and build
-                cl_int binary_status      = CL_SUCCESS;
-                cl_program binary_program = ::clCreateProgramWithBinary(
-                  context, 1, &device, &binary_size, (const unsigned char**) &binary, &binary_status, &error);
-                std::cout << "engine create with binary" << std::endl;
-                delete binary;  // done with the binary so delete it
+                cl_int binary_status = CL_SUCCESS;
+                cl_program binary_program =
+                  ::clCreateProgramWithBinary(context, 1, &device, &binary_size, &binary, &binary_status, &error);
+                std::cout << "engine create with binary " << binary_status << " " << error << std::endl;
+                delete[] binary;  // done with the binary so delete it
                 std::cout << "engine deleted the binary" << std::endl;
                 clBuildProgram(binary_program, 1, &device, NULL, NULL, NULL);
                 std::cout << "engine build the program" << std::endl;

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -109,13 +109,14 @@ namespace engine {
                 std::string binary_path = cache_directory + "/" + std::to_string(source_hash) + ".bin";
                 std::ifstream read_binary(binary_path, std::ios::in);
                 std::cout << "engine try read" << std::endl;
+                long length = 0;
                 if (read_binary) {
                     std::cout << "engine reading" << std::endl;
                     char* binary;
 
                     // Get the length
                     read_binary.seekg(0, read_binary.end);
-                    long length = read_binary.tellg();
+                    length = read_binary.tellg();
                     read_binary.seekg(0, read_binary.beg);
                     std::cout << "engine length " << length << std::endl;
                     binary = new char[length];
@@ -185,6 +186,12 @@ namespace engine {
                   ::clReleaseProgram);
                 throw_cl_error(error, "Failed to create program from binary");
                 std::cout << "engine create with binary " << binary_status << " " << error << std::endl;
+
+                for (int i = 0; i < length; i++) {
+                    std::cout << binary[i];
+                }
+                std::cout << std::endl;
+
                 delete[] binary;  // done with the binary so delete it
                 std::cout << "engine deleted the binary" << std::endl;
                 error = clBuildProgram(program, 1, &device, NULL, NULL, NULL);

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -182,11 +182,12 @@ namespace engine {
                     size_t binary_size{};
                     clGetProgramInfo(program, CL_PROGRAM_BINARY_SIZES, sizeof(size_t), &binary_size, nullptr);
                     std::cout << "get the binary size" << std::endl;
-                    std::vector<char> binary_prog{};
-                    binary_prog.reserve(binary_size);
+                    // std::vector<char> binary_prog{};
+                    // binary_prog.reserve(binary_size);
+                    char* binary_prog = new char[binary_size];
                     std::cout << "reserve" << std::endl;
-                    clGetProgramInfo(program, CL_PROGRAM_BINARIES, binary_size, binary_prog.data(), &error);
-                    std::cout << "make var " << binary_prog.data() << " " << error << std::endl;
+                    clGetProgramInfo(program, CL_PROGRAM_BINARIES, binary_size, binary_prog, nullptr);
+                    std::cout << "make var " << std::endl;
                     // try {
                     //     std::ofstream write_binary(binary_path, std::ofstream::binary);
                     //     std::cout << "write" << std::endl;

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -142,6 +142,12 @@ namespace engine {
                 if (read_failed) {
                     std::cout << "read failed, remove the file " << std::endl;
                     std::remove(binary_path.c_str());
+
+                    // reset vars
+                    error                     = CL_SUCCESS;
+                    device                    = nullptr;
+                    std::tie(context, device) = operation::make_context();
+                    queue                     = operation::make_queue(context, device);
                 }
 
                 // The compiled binary doesn't exist, create it

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -144,7 +144,7 @@ namespace engine {
                     // Save the the built program to a file
                     clGetProgramInfo(program, CL_PROGRAM_BINARY_SIZES, sizeof(size_t), &binary_size, nullptr);
                     std::cout << "reserving" << std::endl;
-                    binary->reserve(binary_size);
+                    binary_prog->reserve(binary_size);
                     std::cout << "prog info" << std::endl;
                     clGetProgramInfo(program, CL_PROGRAM_BINARIES, binary_size, &(binary_prog->front()), nullptr);
                     std::cout << "make var " << binary_size << std::endl;

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -123,7 +123,7 @@ namespace engine {
                     read_binary.read(binary, length);
                     if (!read_binary) { throw("Read failed"); }
                     read_binary.close();
-                    std::cout << "engine close file" << std::endl;
+                    std::cout << "engine close file" << &binary << std::endl;
                 }
                 // The compiled binary doesn't exist, create it
                 else {

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -126,6 +126,7 @@ namespace engine {
                                              "-cl-single-precision-constant -cl-fast-relaxed-math -cl-mad-enable",
                                              nullptr,
                                              nullptr);
+
                     // If it didn't work, log and throw an error
                     if (error != CL_SUCCESS) {
                         // Get program build log
@@ -146,6 +147,7 @@ namespace engine {
                     write_binary.write(binary, binary_size);
                     write_binary.close();
                 }
+
                 // Load the binary and build
                 cl_int binary_status = CL_SUCCESS;
                 program              = cl::program(
@@ -162,6 +164,7 @@ namespace engine {
                                          "-cl-single-precision-constant -cl-fast-relaxed-math -cl-mad-enable",
                                          NULL,
                                          NULL);
+                
                 // If it didn't work, log and throw an error
                 if (error != CL_SUCCESS) {
                     // Get program build log
@@ -575,8 +578,8 @@ namespace engine {
                     // Cache for future runs
                     device_points_cache[&mesh] = cl_points;
                 }
-                else { 
-                    cl_points = device_mesh->second; 
+                else {
+                    cl_points = device_mesh->second;
                 }
 
                 // First count the size of the buffer we will need to allocate

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -167,6 +167,7 @@ namespace engine {
                     // Save the the built program to a file
                     clGetProgramInfo(program, CL_PROGRAM_BINARY_SIZES, sizeof(size_t), &binary_size, nullptr);
                     std::cout << "reserving" << std::endl;
+                    binary_prog.clear();
                     binary_prog.reserve(binary_size);
                     std::cout << "prog info" << std::endl;
                     clGetProgramInfo(program, CL_PROGRAM_BINARIES, binary_size, binary_prog.data(), nullptr);

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -140,14 +140,20 @@ namespace engine {
                         throw_cl_error(
                           error, "Error building OpenCL program\n" + std::string(log.begin(), log.begin() + used));
                     }
-
+                    std::cout << "built" << std::endl;
                     // Save the the built program to a file
                     clGetProgramInfo(program, CL_PROGRAM_BINARY_SIZES, sizeof(size_t), &binary_size, nullptr);
+                    std::cout << "reserving" << std::endl;
                     binary.reserve(binary_size);
+                    std::cout << "prog info" << std::endl;
                     clGetProgramInfo(program, CL_PROGRAM_BINARIES, binary_size, &binary[0], nullptr);
+                    std::cout << "make var" << std::endl;
                     std::ofstream write_binary(binary_path, std::ofstream::binary);
+                    std::cout << "write" << std::endl;
                     write_binary.write(&binary[0], binary_size);
+                    std::cout << "close" << std::endl;
                     write_binary.close();
+                    std::cout << "done" << std::endl;
                 }
                 std::cout << "Compiling with binary" << std::endl;
                 // Load the binary and build

--- a/cpp/visualmesh/engine/opencl/engine.hpp
+++ b/cpp/visualmesh/engine/opencl/engine.hpp
@@ -23,7 +23,6 @@
 
 #include <fstream>
 #include <iomanip>
-#include <iostream>
 #include <numeric>
 #include <sstream>
 #include <tuple>


### PR DESCRIPTION
Building OpenCL can take a while. A solution is to save the compiled binary and load it whenever it is needed. Wait time will exist for the initial run, but after that it should be quick unless the compiled binary is deleted. This PR implements this functionality.